### PR TITLE
Fix post-link.bat

### DIFF
--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,5 @@
 @echo off
 
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable qgrid --py --sys-prefix
-if %ERRORLEVEL% neq 0 exit 1
+:: Set PATH explicitly as it may not be set correctly by some versions of conda
+set "PATH=%PATH%;%PREFIX%\Library\bin"
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable qgrid --py --prefix %PREFIX% >>"%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,4 @@
 @echo off
 
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable qgrid --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable qgrid --py --sys-prefix
+if %ERRORLEVEL% neq 0 exit 1


### PR DESCRIPTION
Trying to install `qgrid` on win64/py37 fails at the post-link stage..

I would've opened an issue but they're not enabled for this repo so I put in this PR instead. This PR won't fix the problem but it should at least give someone a fighting chance to debug it.

Piping stdout/stderr to NUL seems like a *terrible* thing to do as it means there's no way to see what went wrong so irrespective of the underlying issue this change is probably good?